### PR TITLE
Get img element size from options

### DIFF
--- a/gravatar.js
+++ b/gravatar.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -35,6 +34,7 @@ exports.url = function (email, config) {
 
 exports.img = function (email, config) {
   config = config || {};
+  var size = config.s || config.size;
   var url = exports.url(email, config);
   var el = document.createElement('img');
   el.setAttribute('src', url);


### PR DESCRIPTION
Small bug fix. Since we're not passing in size anymore we should be pulling it from the options in `img`.
